### PR TITLE
Adding income dependent time disutility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>vsp</artifactId>
+			<version>${matsim.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>one.util</groupId>
 			<artifactId>streamex</artifactId>
 			<version>0.7.3</version>

--- a/src/main/java/org/matsim/run/RunKelheimScenario.java
+++ b/src/main/java/org/matsim/run/RunKelheimScenario.java
@@ -37,7 +37,6 @@ import org.matsim.core.scoring.functions.ScoringParametersForPerson;
 import org.matsim.drtFare.KelheimDrtFareModule;
 import org.matsim.run.prepare.PreparePopulation;
 import picocli.CommandLine;
-import playground.vsp.pt.fare.PtFareModule;
 import playground.vsp.scoring.IncomeDependentUtilityOfMoneyPersonScoringParameters;
 
 import javax.annotation.Nullable;
@@ -166,9 +165,7 @@ public class RunKelheimScenario extends MATSimApplication {
                 }
             }
         });
-
-        // PT fare module
-        controler.addOverridingModule(new PtFareModule());
+        
 
         if (drt) {
             Config config = controler.getConfig();

--- a/src/main/java/org/matsim/run/RunKelheimScenario.java
+++ b/src/main/java/org/matsim/run/RunKelheimScenario.java
@@ -55,122 +55,127 @@ import java.util.Set;
 })
 public class RunKelheimScenario extends MATSimApplication {
 
-	static final String VERSION = "1.0";
+    static final String VERSION = "1.0";
 
-	@CommandLine.Mixin
-	private final SampleOptions sample = new SampleOptions(25, 10, 1);
+    @CommandLine.Mixin
+    private final SampleOptions sample = new SampleOptions(25, 10, 1);
 
-	@CommandLine.Option(names = "--with-drt", defaultValue = "false", description = "enable DRT service")
-	private boolean drt;
+    @CommandLine.Option(names = "--with-drt", defaultValue = "false", description = "enable DRT service")
+    private boolean drt;
 
-	public RunKelheimScenario(@Nullable Config config) {
-		super(config);
-	}
+    @CommandLine.Option(names = "--income-dependent", defaultValue = "false", description = "enable income dependent monetary utility")
+    private boolean incomeDependent;
 
-	public RunKelheimScenario() {
-		super(String.format("scenarios/input/kelheim-v%s-25pct.config.xml", VERSION));
-	}
+    public RunKelheimScenario(@Nullable Config config) {
+        super(config);
+    }
 
-	public static void main(String[] args) {
-		MATSimApplication.run(RunKelheimScenario.class, args);
-	}
+    public RunKelheimScenario() {
+        super(String.format("scenarios/input/kelheim-v%s-25pct.config.xml", VERSION));
+    }
 
-	@Nullable
-	@Override
-	protected Config prepareConfig(Config config) {
+    public static void main(String[] args) {
+        MATSimApplication.run(RunKelheimScenario.class, args);
+    }
 
-		for (long ii = 600; ii <= 97200; ii += 600) {
+    @Nullable
+    @Override
+    protected Config prepareConfig(Config config) {
 
-			for (String act : List.of("home", "restaurant", "other", "visit", "errands",
-					"educ_higher", "educ_secondary", "educ_primary", "educ_tertiary", "educ_kiga", "educ_other")) {
-				config.planCalcScore()
-						.addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams(act + "_" + ii + ".0").setTypicalDuration(ii));
-			}
+        for (long ii = 600; ii <= 97200; ii += 600) {
 
-			config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("work_" + ii + ".0").setTypicalDuration(ii)
-					.setOpeningTime(6. * 3600.).setClosingTime(20. * 3600.));
-			config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("business_" + ii + ".0").setTypicalDuration(ii)
-					.setOpeningTime(6. * 3600.).setClosingTime(20. * 3600.));
-			config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("leisure_" + ii + ".0").setTypicalDuration(ii)
-					.setOpeningTime(9. * 3600.).setClosingTime(27. * 3600.));
+            for (String act : List.of("home", "restaurant", "other", "visit", "errands",
+                    "educ_higher", "educ_secondary", "educ_primary", "educ_tertiary", "educ_kiga", "educ_other")) {
+                config.planCalcScore()
+                        .addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams(act + "_" + ii + ".0").setTypicalDuration(ii));
+            }
 
-			config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("shop_daily_" + ii + ".0").setTypicalDuration(ii)
-					.setOpeningTime(8. * 3600.).setClosingTime(20. * 3600.));
-			config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("shop_other_" + ii + ".0").setTypicalDuration(ii)
-					.setOpeningTime(8. * 3600.).setClosingTime(20. * 3600.));
-		}
+            config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("work_" + ii + ".0").setTypicalDuration(ii)
+                    .setOpeningTime(6. * 3600.).setClosingTime(20. * 3600.));
+            config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("business_" + ii + ".0").setTypicalDuration(ii)
+                    .setOpeningTime(6. * 3600.).setClosingTime(20. * 3600.));
+            config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("leisure_" + ii + ".0").setTypicalDuration(ii)
+                    .setOpeningTime(9. * 3600.).setClosingTime(27. * 3600.));
 
-		config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("car interaction").setTypicalDuration(60));
-		config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("other").setTypicalDuration(600 * 3));
+            config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("shop_daily_" + ii + ".0").setTypicalDuration(ii)
+                    .setOpeningTime(8. * 3600.).setClosingTime(20. * 3600.));
+            config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("shop_other_" + ii + ".0").setTypicalDuration(ii)
+                    .setOpeningTime(8. * 3600.).setClosingTime(20. * 3600.));
+        }
 
-		config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("freight_start").setTypicalDuration(60 * 15));
-		config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("freight_end").setTypicalDuration(60 * 15));
+        config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("car interaction").setTypicalDuration(60));
+        config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("other").setTypicalDuration(600 * 3));
 
-		config.controler().setOutputDirectory(sample.adjustName(config.controler().getOutputDirectory()));
-		config.plans().setInputFile(sample.adjustName(config.plans().getInputFile()));
+        config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("freight_start").setTypicalDuration(60 * 15));
+        config.planCalcScore().addActivityParams(new PlanCalcScoreConfigGroup.ActivityParams("freight_end").setTypicalDuration(60 * 15));
 
-		config.qsim().setFlowCapFactor(sample.getSize() / 100.0);
-		config.qsim().setStorageCapFactor(sample.getSize() / 100.0);
+        config.controler().setOutputDirectory(sample.adjustName(config.controler().getOutputDirectory()));
+        config.plans().setInputFile(sample.adjustName(config.plans().getInputFile()));
 
-		config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.info);
-		config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
+        config.qsim().setFlowCapFactor(sample.getSize() / 100.0);
+        config.qsim().setStorageCapFactor(sample.getSize() / 100.0);
 
-		if (drt) {
-			MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
-			ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
-			DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.planCalcScore(), config.plansCalcRoute());
-		}
+        config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.info);
+        config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
 
-		return config;
-	}
+        if (drt) {
+            MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
+            ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
+            DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.planCalcScore(), config.plansCalcRoute());
+        }
 
-	@Override
-	protected void prepareScenario(Scenario scenario) {
+        return config;
+    }
 
-		for (Link link : scenario.getNetwork().getLinks().values()) {
-			Set<String> modes = link.getAllowedModes();
+    @Override
+    protected void prepareScenario(Scenario scenario) {
 
-			// allow freight traffic together with cars
-			if (modes.contains("car")) {
-				HashSet<String> newModes = Sets.newHashSet(modes);
-				newModes.add("freight");
+        for (Link link : scenario.getNetwork().getLinks().values()) {
+            Set<String> modes = link.getAllowedModes();
 
-				link.setAllowedModes(newModes);
-			}
-		}
+            // allow freight traffic together with cars
+            if (modes.contains("car")) {
+                HashSet<String> newModes = Sets.newHashSet(modes);
+                newModes.add("freight");
 
-		if (drt) {
-			scenario.getPopulation()
-					.getFactory()
-					.getRouteFactories()
-					.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
-		}
-	}
+                link.setAllowedModes(newModes);
+            }
+        }
 
-	@Override
-	protected void prepareControler(Controler controler) {
-		controler.addOverridingModule(new AbstractModule() {
-			@Override
-			public void install() {
-				install(new SwissRailRaptorModule());
-				bind(AnalysisMainModeIdentifier.class).to(KelheimMainModeIdentifier.class);
-				addControlerListenerBinding().to(ModeChoiceCoverageControlerListener.class);
-				bind(ScoringParametersForPerson.class).to(IncomeDependentUtilityOfMoneyPersonScoringParameters.class).asEagerSingleton();
-			}
-		});
+        if (drt) {
+            scenario.getPopulation()
+                    .getFactory()
+                    .getRouteFactories()
+                    .setRouteFactory(DrtRoute.class, new DrtRouteFactory());
+        }
+    }
 
-		if (drt) {
-			Config config = controler.getConfig();
-			Scenario scenario = controler.getScenario();
-			Network network = scenario.getNetwork();
-			MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
-			controler.addOverridingModule(new DvrpModule());
-			controler.addOverridingModule(new MultiModeDrtModule());
-			controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
-			for (DrtConfigGroup drtCfg : multiModeDrtConfig.getModalElements()) {
-				controler.addOverridingModule(new KelheimDrtFareModule(drtCfg, network));
-			}
+    @Override
+    protected void prepareControler(Controler controler) {
+        controler.addOverridingModule(new AbstractModule() {
+            @Override
+            public void install() {
+                install(new SwissRailRaptorModule());
+                bind(AnalysisMainModeIdentifier.class).to(KelheimMainModeIdentifier.class);
+                addControlerListenerBinding().to(ModeChoiceCoverageControlerListener.class);
+                if (incomeDependent) {
+                    bind(ScoringParametersForPerson.class).to(IncomeDependentUtilityOfMoneyPersonScoringParameters.class).asEagerSingleton();
+                }
+            }
+        });
 
-		}
-	}
+        if (drt) {
+            Config config = controler.getConfig();
+            Scenario scenario = controler.getScenario();
+            Network network = scenario.getNetwork();
+            MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
+            controler.addOverridingModule(new DvrpModule());
+            controler.addOverridingModule(new MultiModeDrtModule());
+            controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
+            for (DrtConfigGroup drtCfg : multiModeDrtConfig.getModalElements()) {
+                controler.addOverridingModule(new KelheimDrtFareModule(drtCfg, network));
+            }
+
+        }
+    }
 }

--- a/src/main/java/org/matsim/run/RunKelheimScenario.java
+++ b/src/main/java/org/matsim/run/RunKelheimScenario.java
@@ -33,9 +33,11 @@ import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.scoring.functions.ScoringParametersForPerson;
 import org.matsim.drtFare.KelheimDrtFareModule;
 import org.matsim.run.prepare.PreparePopulation;
 import picocli.CommandLine;
+import playground.vsp.scoring.IncomeDependentUtilityOfMoneyPersonScoringParameters;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -153,6 +155,7 @@ public class RunKelheimScenario extends MATSimApplication {
 				install(new SwissRailRaptorModule());
 				bind(AnalysisMainModeIdentifier.class).to(KelheimMainModeIdentifier.class);
 				addControlerListenerBinding().to(ModeChoiceCoverageControlerListener.class);
+				bind(ScoringParametersForPerson.class).to(IncomeDependentUtilityOfMoneyPersonScoringParameters.class).asEagerSingleton();
 			}
 		});
 

--- a/src/main/java/org/matsim/run/RunKelheimScenario.java
+++ b/src/main/java/org/matsim/run/RunKelheimScenario.java
@@ -37,6 +37,7 @@ import org.matsim.core.scoring.functions.ScoringParametersForPerson;
 import org.matsim.drtFare.KelheimDrtFareModule;
 import org.matsim.run.prepare.PreparePopulation;
 import picocli.CommandLine;
+import playground.vsp.pt.fare.PtFareModule;
 import playground.vsp.scoring.IncomeDependentUtilityOfMoneyPersonScoringParameters;
 
 import javax.annotation.Nullable;
@@ -152,6 +153,8 @@ public class RunKelheimScenario extends MATSimApplication {
 
     @Override
     protected void prepareControler(Controler controler) {
+        Network network = controler.getScenario().getNetwork();
+
         controler.addOverridingModule(new AbstractModule() {
             @Override
             public void install() {
@@ -164,10 +167,11 @@ public class RunKelheimScenario extends MATSimApplication {
             }
         });
 
+        // PT fare module
+        controler.addOverridingModule(new PtFareModule());
+
         if (drt) {
             Config config = controler.getConfig();
-            Scenario scenario = controler.getScenario();
-            Network network = scenario.getNetwork();
             MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
             controler.addOverridingModule(new DvrpModule());
             controler.addOverridingModule(new MultiModeDrtModule());

--- a/src/main/java/org/matsim/run/prepare/PreparePopulation.java
+++ b/src/main/java/org/matsim/run/prepare/PreparePopulation.java
@@ -95,6 +95,16 @@ public class PreparePopulation implements MATSimAppCommand {
                     break;
                 case 10:
                     income = (rnd.nextInt(3000) + 7000) / householdSize;
+                    double superRichFactor = rnd.nextDouble();
+                    if (superRichFactor < 0.01){
+                        income += rnd.nextInt(10000);
+                    }
+                    if (superRichFactor < 0.001){
+                        income += rnd.nextInt(100000);
+                    }
+                    if (superRichFactor < 0.0001){
+                        income += rnd.nextInt(1000000);
+                    }
                     break;
                 default:
                     income = 2364; // Average monthly household income per Capita (2021). See comments below for details

--- a/src/main/java/org/matsim/run/prepare/PreparePopulation.java
+++ b/src/main/java/org/matsim/run/prepare/PreparePopulation.java
@@ -50,6 +50,10 @@ public class PreparePopulation implements MATSimAppCommand {
             PersonUtils.setCarAvail(person, avail);
 
             // Assign income to person
+            if (person.getId().toString().startsWith("freight")){
+                continue;
+            }
+
             String incomeGroupString = (String) person.getAttributes().getAttribute("MiD:hheink_gr2");
             String householdSizeString = (String) person.getAttributes().getAttribute("MiD:hhgr_gr");
             int incomeGroup = 0;
@@ -93,12 +97,18 @@ public class PreparePopulation implements MATSimAppCommand {
                     income = (rnd.nextInt(3000) + 7000) / householdSize;
                     break;
                 default:
-                    income = 2389.0; // Average monthly household income per Capita (2018)
+                    income = 2364; // Average monthly household income per Capita (2021). See comments below for details
                     break;
+                    // Average Gross household income: 4734 Euro
+                    // Average household size: 83.1M persons /41.5M households = 2.0 persons / household
+                    // Average household income per capita: 4734/2.0 = 2364 Euro
+                    // Source (Access date: 21 Sep. 2021):
+                    // https://www.destatis.de/EN/Themes/Society-Environment/Income-Consumption-Living-Conditions/Income-Receipts-Expenditure/_node.html
+                    // https://www.destatis.de/EN/Themes/Society-Environment/Population/Households-Families/_node.html
+                    // https://www.destatis.de/EN/Themes/Society-Environment/Population/Current-Population/_node.html;jsessionid=E0D7A060D654B31C3045AAB1E884CA75.live711
             }
             person.getAttributes().putAttribute("income", income);
         }
-
         PopulationUtils.writePopulation(population, output.toString());
 
         return 0;

--- a/src/main/java/org/matsim/run/prepare/PreparePopulation.java
+++ b/src/main/java/org/matsim/run/prepare/PreparePopulation.java
@@ -94,17 +94,7 @@ public class PreparePopulation implements MATSimAppCommand {
                     income = (rnd.nextInt(1000) + 6000) / householdSize;
                     break;
                 case 10:
-                    income = (rnd.nextInt(3000) + 7000) / householdSize;
-                    double superRichFactor = rnd.nextDouble();
-                    if (superRichFactor < 0.01){
-                        income += rnd.nextInt(10000);
-                    }
-                    if (superRichFactor < 0.001){
-                        income += rnd.nextInt(100000);
-                    }
-                    if (superRichFactor < 0.0001){
-                        income += rnd.nextInt(1000000);
-                    }
+                    income = (Math.abs(rnd.nextGaussian()) * 1000 + 7000) / householdSize;
                     break;
                 default:
                     income = 2364; // Average monthly household income per Capita (2021). See comments below for details

--- a/src/main/java/org/matsim/run/prepare/PreparePopulation.java
+++ b/src/main/java/org/matsim/run/prepare/PreparePopulation.java
@@ -96,7 +96,7 @@ public class PreparePopulation implements MATSimAppCommand {
                     income = 2389.0; // Average monthly household income per Capita (2018)
                     break;
             }
-            person.getAttributes().putAttribute("income", Double.toString(income));
+            person.getAttributes().putAttribute("income", income);
         }
 
         PopulationUtils.writePopulation(population, output.toString());


### PR DESCRIPTION
Part 1: Modify the prepare population file. now the income will be added to the attribute based on the statistics. As the first step, income per person is calculated based on a random value within the income group divided by household size.

Part 2: Add the binding line in run script. It is now configurable. By default, it will be turned off (so that it does not impact the current test).