### PR TITLE
Adding congestion analysis

### DIFF
--- a/src/main/java/org/matsim/analysis/postAnalysis/TrafficAnalysis.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/TrafficAnalysis.java
@@ -1,0 +1,160 @@
+package org.matsim.analysis.postAnalysis;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.application.MATSimAppCommand;
+import org.matsim.application.options.ShpOptions;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.MatsimEventsReader;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
+import org.matsim.core.utils.geometry.geotools.MGC;
+import picocli.CommandLine;
+
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@CommandLine.Command(
+        name = "analyze-traffic",
+        description = "Write traffic condition"
+)
+public class TrafficAnalysis implements MATSimAppCommand {
+    @CommandLine.Option(names = "--network", description = "path to network file", required = true)
+    private String networkFile;
+
+    @CommandLine.Option(names = "--events", description = "path to events file", required = true)
+    private String eventsFile;
+
+    @CommandLine.Option(names = "--output", description = "output path", required = true)
+    private String output;
+
+    @CommandLine.Option(names = "--interval", description = "observation interval (in seconds). Default is 900 seconds (15 min)", defaultValue = "900")
+    private double timeInterval;
+
+    @CommandLine.Mixin
+    private ShpOptions shp = new ShpOptions();
+
+    private static final Logger log = LogManager.getLogger(TrafficAnalysis.class);
+
+    public static void main(String[] args) {
+        new TrafficAnalysis().execute(args);
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        Network network = NetworkUtils.readTimeInvariantNetwork(networkFile);
+        TravelTimeCalculator.Builder builder = new TravelTimeCalculator.Builder(network);
+        TravelTimeCalculator travelTimeCalculator = builder.build();
+
+        // event reader add event handeler travelTimeCalculator
+        log.info("Begin analyzing travel time from events file...");
+        EventsManager eventsManager = EventsUtils.createEventsManager();
+        eventsManager.addHandler(travelTimeCalculator);
+        MatsimEventsReader eventsReader = new MatsimEventsReader(eventsManager);
+        eventsReader.readFile(eventsFile);
+
+        // Actual TravelTime based on the events file
+        TravelTime travelTime = travelTimeCalculator.getLinkTravelTimes();
+
+        Geometry studyArea = null;
+        if (shp.getShapeFile() != null && !shp.getShapeFile().toString().equals("")) {
+            studyArea = shp.getGeometry();
+        }
+
+        log.info("Begin writing out results...");
+        log.info("There are in total " + network.getLinks().size() + " links in the network");
+        Map<Double, List<Double>> networkSpeedRatiosMap = new HashMap<>();
+        double networkCongestionIndex = 0;
+        double totalLength = 0;
+        List<String> titleRow = new ArrayList<>();
+        titleRow.add("link_id");
+        titleRow.add("congestion_index");
+        titleRow.add("average_daily_speed");
+        for (double i = 0; i < 86400; i += timeInterval) {
+            networkSpeedRatiosMap.put(i, new ArrayList<>());
+            titleRow.add(Double.toString(i));
+        }
+
+        CSVPrinter csvWriter = new CSVPrinter(new FileWriter(output), CSVFormat.DEFAULT);
+        csvWriter.printRecord(titleRow);
+
+        int processed = 0;
+        for (Link link : network.getLinks().values()) {
+            processed += 1;
+            if (processed % 10000 == 0) {
+                log.info("Processing: " + processed + " links have been processed");
+            }
+            if (!link.getAllowedModes().contains("car")) {
+                continue;
+            }
+
+            if (link.getLength() < 10) {
+                continue; // Links that are too short can produce extreme values and make the analysis not accurate
+            }
+
+            boolean isLinkWithinStudyArea = MGC.coord2Point(link.getToNode().getCoord()).within(studyArea) ||
+                    MGC.coord2Point(link.getFromNode().getCoord()).within(studyArea);
+            if (!isLinkWithinStudyArea && studyArea != null) {
+                continue;
+            }
+
+            List<Double> linksSpeedRatios = new ArrayList<>();
+            double counter = 0;
+            double congestedPeriods = 0;
+            for (double t = 0; t < 86400; t += timeInterval) {
+                double freeSpeedTravelTime = Math.floor(link.getLength() / link.getFreespeed()) + 1;
+                double actualTravelTime = travelTime.getLinkTravelTime(link, t, null, null);
+                double speedRatio = freeSpeedTravelTime / actualTravelTime;
+                if (speedRatio > 1) {
+                    speedRatio = 1;
+                }
+                networkSpeedRatiosMap.get(t).add(speedRatio);
+                linksSpeedRatios.add(speedRatio);
+                counter++;
+                if (speedRatio <= 0.5) {
+                    congestedPeriods++;
+                }
+            }
+            double linkDailyAverageSpeed = linksSpeedRatios.stream().mapToDouble(s -> s).average().orElse(-1);
+            double linkCongestionIndex = linkDailyAverageSpeed * (1 - congestedPeriods / counter);
+            List<String> outputRow = new ArrayList<>();
+            outputRow.add(link.getId().toString());
+            outputRow.add(Double.toString(linkCongestionIndex));
+            outputRow.add(Double.toString(linkDailyAverageSpeed));
+            outputRow.addAll(linksSpeedRatios.stream().map(s -> Double.toString(s)).collect(Collectors.toList()));
+            csvWriter.printRecord(outputRow);
+
+            networkCongestionIndex += linkCongestionIndex * link.getLength();
+            totalLength += link.getLength();
+        }
+
+        // final row (whole network)
+        networkCongestionIndex = networkCongestionIndex / totalLength;
+        List<Double> networkSpeedRatios = new ArrayList<>();
+        for (Double t : networkSpeedRatiosMap.keySet()) {
+            double averageSpeedRatioForTimePeriod = networkSpeedRatiosMap.get(t).stream().mapToDouble(s -> s).average().orElse(-1);
+            networkSpeedRatios.add(averageSpeedRatioForTimePeriod);
+        }
+
+        List<String> lastRow = new ArrayList<>();
+        lastRow.add("full_network");
+        lastRow.add(Double.toString(networkCongestionIndex));
+        lastRow.add(Double.toString(networkSpeedRatios.stream().mapToDouble(s -> s).average().orElse(-1)));
+        lastRow.addAll(networkSpeedRatios.stream().map(s -> Double.toString(s)).collect(Collectors.toList()));
+        csvWriter.printRecord(lastRow);
+        csvWriter.close();
+
+        return 0;
+    }
+}

--- a/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/CongestionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/CongestionAnalysis.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @CommandLine.Command(
-        name = "analyze-traffic",
-        description = "Write traffic condition"
+        name = "analyze-congestion",
+        description = "Write traffic condition analysis and calculate congestion index of the network"
 )
 public class CongestionAnalysis implements MATSimAppCommand {
     @CommandLine.Option(names = "--network", description = "path to network file", required = true)
@@ -90,8 +90,8 @@ public class CongestionAnalysis implements MATSimAppCommand {
             networkSpeedRatiosMap.put(i, new ArrayList<>());
             titleRow.add(Double.toString(i));
         }
-        CSVPrinter csvWriter = new CSVPrinter(new FileWriter(output), CSVFormat.TDF);
-        csvWriter.printRecord(titleRow);
+        CSVPrinter tsvWriter = new CSVPrinter(new FileWriter(output), CSVFormat.TDF);
+        tsvWriter.printRecord(titleRow);
 
         int processed = 0;
         for (Link link : network.getLinks().values()) {
@@ -128,7 +128,7 @@ public class CongestionAnalysis implements MATSimAppCommand {
             outputRow.add(Double.toString(linkCongestionIndex));
             outputRow.add(Double.toString(linkDailyAverageSpeed));
             outputRow.addAll(linksSpeedRatios.stream().map(s -> Double.toString(s)).collect(Collectors.toList()));
-            csvWriter.printRecord(outputRow);
+            tsvWriter.printRecord(outputRow);
 
             networkCongestionIndex += linkCongestionIndex * link.getLength();
             totalLength += link.getLength();
@@ -147,8 +147,8 @@ public class CongestionAnalysis implements MATSimAppCommand {
         lastRow.add(Double.toString(networkCongestionIndex));
         lastRow.add(Double.toString(networkSpeedRatios.stream().mapToDouble(s -> s).average().orElse(-1)));
         lastRow.addAll(networkSpeedRatios.stream().map(s -> Double.toString(s)).collect(Collectors.toList()));
-        csvWriter.printRecord(lastRow);
-        csvWriter.close();
+        tsvWriter.printRecord(lastRow);
+        tsvWriter.close();
 
         return 0;
     }

--- a/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/CongestionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/CongestionAnalysis.java
@@ -90,7 +90,7 @@ public class CongestionAnalysis implements MATSimAppCommand {
             networkSpeedRatiosMap.put(i, new ArrayList<>());
             titleRow.add(Double.toString(i));
         }
-        CSVPrinter csvWriter = new CSVPrinter(new FileWriter(output), CSVFormat.DEFAULT);
+        CSVPrinter csvWriter = new CSVPrinter(new FileWriter(output), CSVFormat.TDF);
         csvWriter.printRecord(titleRow);
 
         int processed = 0;

--- a/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/LinkFilter.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/trafficAnalysis/LinkFilter.java
@@ -1,0 +1,64 @@
+package org.matsim.analysis.postAnalysis.trafficAnalysis;
+
+import org.apache.commons.lang.mutable.MutableInt;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.utils.geometry.geotools.MGC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LinkFilter implements LinkEnterEventHandler, VehicleEntersTrafficEventHandler {
+    private final Geometry studyArea;
+    private final int minimumDailyTrafficCount;
+    Map<Id<Link>, MutableInt> linksTrafficCountMap = new HashMap<>();
+
+    public LinkFilter(Geometry studyArea, int minimumDailyTrafficCount) {
+        this.studyArea = studyArea;
+        this.minimumDailyTrafficCount = minimumDailyTrafficCount;
+    }
+
+    public boolean checkIfConsiderTheLink(Link link) {
+        if (!link.getAllowedModes().contains(TransportMode.car)) {
+            return false;
+        }
+
+        // Links that are too short may produce extreme values, which may influence the results
+        if (link.getLength() < 10) {
+            return false;
+        }
+
+        // Remove the links that is outside the study area
+        if (studyArea != null) {
+            boolean fromNodeIsInStudyArea = MGC.coord2Point(link.getFromNode().getCoord()).within(studyArea);
+            boolean toNodeIsInStudyArea = MGC.coord2Point(link.getToNode().getCoord()).within(studyArea);
+            if (!fromNodeIsInStudyArea && !toNodeIsInStudyArea) {
+                return false;
+            }
+        }
+        return linksTrafficCountMap.getOrDefault(link.getId(), new MutableInt()).intValue() >= minimumDailyTrafficCount;
+    }
+
+    @Override
+    public void handleEvent(LinkEnterEvent linkEnterEvent) {
+        Id<Link> linkId = linkEnterEvent.getLinkId();
+        linksTrafficCountMap.computeIfAbsent(linkId, v -> new MutableInt()).increment();
+    }
+
+    @Override
+    public void handleEvent(VehicleEntersTrafficEvent vehicleEntersTrafficEvent) {
+        Id<Link> linkId = vehicleEntersTrafficEvent.getLinkId();
+        linksTrafficCountMap.computeIfAbsent(linkId, v -> new MutableInt()).increment();
+    }
+
+    @Override
+    public void reset(int iteration) {
+        linksTrafficCountMap.clear();
+    }
+}

--- a/src/main/java/org/matsim/run/prepare/PrepareNetworkChangeEvents.java
+++ b/src/main/java/org/matsim/run/prepare/PrepareNetworkChangeEvents.java
@@ -21,13 +21,13 @@ import java.util.List;
         description = "Write network change events based on output events"
 )
 public class PrepareNetworkChangeEvents implements MATSimAppCommand {
-    @CommandLine.Option(names= "--network", description = "path to drt stop xml file", required = true)
+    @CommandLine.Option(names= "--network", description = "path to network file", required = true)
     private String networkFile;
 
-    @CommandLine.Option(names= "--events", description = "path to real drt demand csv file", required = true)
+    @CommandLine.Option(names= "--events", description = "path to events file", required = true)
     private String eventsFile;
 
-    @CommandLine.Option(names= "--output", description = "path to real drt demand csv file", required = true)
+    @CommandLine.Option(names= "--output", description = "output path", required = true)
     private String output;
 
     public static void main(String[] args) {


### PR DESCRIPTION
The traffic analysis script will produce the following useful data:
1. A single congestion index for the whole network (within the optinal shape file) --> This can be useful for the Dusseldorf scenario also!!!
2. Congestion index and average speed ratio for all the links (within the optinal shape file) in the network 
3. Average speed ratio of the whole netowork (within the optinal shape file) throughout the day (15-mintues interval)
4. Detailed statisctics for further analysis and plotting. 

Difference to the LinkStat: The time interval is adjustable. Congestion index is provided.

Further improvments:
Enable input of selected links (e.g. only include major roads and do not include the smaller roads)