### PR TITLE
Add Deprecated annotation to CongestionAnalysis.java

### DIFF
--- a/src/main/java/org/matsim/analysis/postAnalysis/traffic/CongestionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/traffic/CongestionAnalysis.java
@@ -23,9 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 /**
  * This function has already been moved to matsim-lib. Please use the org.matsim.application.analysis.LinkStats instead
- * */
+ */
 @Deprecated
 @CommandLine.Command(
         name = "analyze-congestion",

--- a/src/main/java/org/matsim/analysis/postAnalysis/traffic/CongestionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/postAnalysis/traffic/CongestionAnalysis.java
@@ -23,7 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
+/**
+ * This function has already been moved to matsim-lib. Please use the org.matsim.application.analysis.LinkStats instead
+ * */
+@Deprecated
 @CommandLine.Command(
         name = "analyze-congestion",
         description = "Write traffic condition analysis and calculate congestion index of the network"


### PR DESCRIPTION
This function has been moved to the matsim-lib. For furture analysis, please use the LinkStats instead.