### PR TITLE
return intermodal mode identifier for drt+pt trips

### DIFF
--- a/src/main/java/org/matsim/analysis/KelheimMainModeIdentifier.java
+++ b/src/main/java/org/matsim/analysis/KelheimMainModeIdentifier.java
@@ -91,9 +91,7 @@ public class KelheimMainModeIdentifier implements AnalysisMainModeIdentifier {
                     throw new RuntimeException("unknown intermodal pt trip");
                 }
             }
-
-            return TransportMode.pt;
-
+            return isDrtPt ? ANALYSIS_MAIN_MODE_PT_WITH_DRT_USED_FOR_ACCESS_OR_EGRESS : TransportMode.pt;
         } else {
             return mainMode;
         }


### PR DESCRIPTION
So far, we have not tagged intermodal pt+drt trips specifically. Maybe there was a reason for that? Otherwise, this PR proposes to distinguish between pt and pt+drt trips (for analysis purposes)