### PR TITLE
feat: StartLinkAsDepot + refactor package name

### DIFF
--- a/src/main/java/org/matsim/drt/KelheimDrtFareHandler.java
+++ b/src/main/java/org/matsim/drt/KelheimDrtFareHandler.java
@@ -1,4 +1,4 @@
-package org.matsim.drtFare;
+package org.matsim.drt;
 
 import com.google.inject.Inject;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/matsim/drt/KelheimDrtFareModule.java
+++ b/src/main/java/org/matsim/drt/KelheimDrtFareModule.java
@@ -1,4 +1,4 @@
-package org.matsim.drtFare;
+package org.matsim.drt;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.run.DrtConfigGroup;

--- a/src/main/java/org/matsim/drt/KelheimDrtFareParams.java
+++ b/src/main/java/org/matsim/drt/KelheimDrtFareParams.java
@@ -11,14 +11,14 @@ import java.util.Map;
 @SuppressWarnings({"MemberName", "MethodName"})
 public final class KelheimDrtFareParams extends ReflectiveConfigGroup {
 	public static final String SET_NAME = "kelheimDrtFare";
-	public static final String BASEFARE = "baseFare";
+	public static final String BASE_FARE = "baseFare";
 	public static final String ZONE_2_SURCHARGE = "zone2Surcharge";
 	public static final String MINFARE_PER_TRIP = "minFarePerTrip";
 	public static final String DAILY_FEE = "dailySubscriptionFee";
 	public static final String TIMEFARE = "timeFare_h";
 	public static final String DISTANCEFARE = "distanceFare_m";
-	public static final String MODE = "mode";
-	public static final String SHAPEFILE = "shapeFile";
+	public static final String DRT_MODE = "mode";
+	public static final String SHAPE_FILE = "shapeFile";
 
 	@PositiveOrZero
 	private double baseFare;
@@ -47,24 +47,24 @@ public final class KelheimDrtFareParams extends ReflectiveConfigGroup {
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
-		map.put(BASEFARE, "Basefare per trip: 2 EUR (For trips within zone 1 base fare will be charged)");
+		map.put(BASE_FARE, "Basefare per trip: 2 EUR (For trips within zone 1 base fare will be charged)");
 		map.put(ZONE_2_SURCHARGE, "Surcharge for trips traveling to/within zone 2: 1 EUR");
 		map.put(MINFARE_PER_TRIP,
 				"Minimum fare per trip (paid instead of the sum of base, time and distance fare if that sum would be lower than the minimum fare, positive or zero value).");
 		map.put(DAILY_FEE, "Daily subscription fee (positive or zero value)");
 		map.put(TIMEFARE, "drt fare per hour (positive or zero value)");
 		map.put(DISTANCEFARE, "drt fare per meter (positive or zero value)");
-		map.put(MODE, "transport mode for which the fare applies. Default: drt");
-		map.put(SHAPEFILE, "shape file of the DRT fare zonal system");
+		map.put(DRT_MODE, "transport mode for which the fare applies. Default: drt");
+		map.put(SHAPE_FILE, "shape file of the DRT fare zonal system");
 		return map;
 	}
 
-	@StringGetter(BASEFARE)
+	@StringGetter(BASE_FARE)
 	public double getBaseFare() {
 		return baseFare;
 	}
 
-	@StringSetter(BASEFARE)
+	@StringSetter(BASE_FARE)
 	public void setBaseFare(double baseFare) {
 		this.baseFare = baseFare;
 	}
@@ -119,22 +119,22 @@ public final class KelheimDrtFareParams extends ReflectiveConfigGroup {
 		this.distanceFare_m = distanceFare_m;
 	}
 
-	@StringGetter(SHAPEFILE)
+	@StringGetter(SHAPE_FILE)
 	public String getShapeFile() {
 		return shapeFile;
 	}
 
-	@StringSetter(SHAPEFILE)
+	@StringSetter(SHAPE_FILE)
 	public void setShapeFile(String shapeFile) {
 		this.shapeFile = shapeFile;
 	}
 
-	@StringGetter(MODE)
+	@StringGetter(DRT_MODE)
 	public String getMode() {
 		return mode;
 	}
 
-	@StringSetter(MODE)
+	@StringSetter(DRT_MODE)
 	public void setMode(String mode) {
 		this.mode = mode;
 	}

--- a/src/main/java/org/matsim/drt/KelheimDrtFareParams.java
+++ b/src/main/java/org/matsim/drt/KelheimDrtFareParams.java
@@ -1,4 +1,4 @@
-package org.matsim.drtFare;
+package org.matsim.drt;
 
 import jakarta.validation.constraints.PositiveOrZero;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/src/main/java/org/matsim/drt/StartLinkAsDepot.java
+++ b/src/main/java/org/matsim/drt/StartLinkAsDepot.java
@@ -1,0 +1,46 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.drt;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.Fleet;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class StartLinkAsDepot implements DepotFinder {
+
+	private Map<DvrpVehicle, Link> vehicleToStartLink;
+
+	public StartLinkAsDepot(Fleet fleet) {
+		this.vehicleToStartLink = fleet.getVehicles()
+			.values()
+			.stream()
+			.collect(Collectors.toUnmodifiableMap(v -> v, DvrpVehicle::getStartLink));
+	}
+	@Override
+	public Link findDepot(DvrpVehicle vehicle) {
+		return vehicleToStartLink.get(vehicle);
+	}
+
+}

--- a/src/main/java/org/matsim/drt/StartLinkAsDepot.java
+++ b/src/main/java/org/matsim/drt/StartLinkAsDepot.java
@@ -28,9 +28,12 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Returns the individual start link of each {@code DvrpVehicle}.
+ */
 public class StartLinkAsDepot implements DepotFinder {
 
-	private Map<DvrpVehicle, Link> vehicleToStartLink;
+	private final Map<DvrpVehicle, Link> vehicleToStartLink;
 
 	public StartLinkAsDepot(Fleet fleet) {
 		this.vehicleToStartLink = fleet.getVehicles()

--- a/src/main/java/org/matsim/run/RunKelheimRealDrtDemands.java
+++ b/src/main/java/org/matsim/run/RunKelheimRealDrtDemands.java
@@ -19,7 +19,7 @@ import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.drtFare.KelheimDrtFareModule;
+import org.matsim.drt.KelheimDrtFareModule;
 import picocli.CommandLine;
 
 import java.nio.file.Path;


### PR DESCRIPTION
1. The package drtFare is renamed to drt
1. Add implementation of `DepotFinder`, where each vehicle is sent back to it's own start link (which is specified when defining the input `DvrpVehicle`s).
1. The implementation called `StartLinkAsDepot` is bound for the drt mode 'av'
